### PR TITLE
macOS / Linux support: shell build & headless scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,17 +45,28 @@ Naming convention: tools are `edt_*` (snake_case); parameters are camelCase (`pr
 
 - **1C:EDT** installed and running, with your project open in the workspace.
 - A **JDK 17+** to build (the bundle's bytecode targets Java 17, the EDT runtime).
-- The local **EDT p2 bundle pool** (used as the offline build target): `<your-home>/.p2/pool/plugins`.
+- The local **EDT bundle pool** (used as the offline build target). On **Windows** that is the
+  p2 pool `<your-home>\.p2\pool\plugins`; on **macOS** the self-contained pool lives inside the
+  installed component: `…/1C/1CE/components/1c-edt-<ver>-x86_64/1cedt (<ver>).app/Contents/Eclipse/plugins`
+  (the shell build auto-detects it).
 
 ## Build
 
 **Option A — no Maven** (quickest; pure local JDK + the EDT pool, no network):
 
 ```powershell
-# defaults: -Pool %USERPROFILE%\.p2\pool\plugins, -JdkHome %JAVA_HOME%
+# Windows — defaults: -Pool %USERPROFILE%\.p2\pool\plugins, -JdkHome %JAVA_HOME%
 powershell -ExecutionPolicy Bypass -File build-nomaven.ps1
 # or override:
 powershell -File build-nomaven.ps1 -Pool "D:\path\.p2\pool\plugins" -JdkHome "C:\path\to\jdk"
+```
+
+```bash
+# macOS / Linux — same output. Defaults: --jdk-home from JAVA_HOME (or `/usr/libexec/java_home -v 17`
+# on macOS); --pool auto-detected from the installed 1C:EDT component pool.
+./build-nomaven.sh
+# or override:
+./build-nomaven.sh --pool "/path/to/Contents/Eclipse/plugins" --jdk-home "/path/to/jdk-17"
 ```
 
 Produces `build/com.e1c.fresh.edtbridge_0.0.1.<timestamp>.jar`.
@@ -68,9 +79,13 @@ mvn -f pom.xml clean verify
 
 ## Install & run
 
-1. Copy the built jar into EDT's `dropins/` folder
-   (e.g. `…/installations/<EDT>/1cedt/dropins/`).
+1. Copy the built jar into EDT's `dropins/` folder — Windows: `…/installations/<EDT>/1cedt/dropins/`;
+   **macOS**: `…/1C/1CE/components/1c-edt-<ver>-x86_64/1cedt (<ver>).app/Contents/Eclipse/dropins/`
+   (create it if it does not exist).
 2. **Restart EDT.** On launch the plugin starts the MCP server on `http://127.0.0.1:8770/mcp`.
+
+To run EDT **headless** (no GUI window) so the server serves the live model, use
+`run-headless.ps1` (Windows) or `run-headless.sh --workspace <ws>` (macOS / Linux).
 
 Smoke-test with curl:
 
@@ -173,16 +188,28 @@ AI-агентам и другим инструментам по протокол
 
 - Установленный и запущенный **1C:EDT** с открытым проектом.
 - **JDK 17+** для сборки (байт-код плагина — Java 17, рантайм EDT).
-- Локальный **p2-пул бандлов EDT** (офлайн-цель сборки): `<домашний-каталог>/.p2/pool/plugins`.
+- Локальный **пул бандлов EDT** (офлайн-цель сборки). На **Windows** это p2-пул
+  `<домашний-каталог>\.p2\pool\plugins`; на **macOS** самодостаточный пул лежит внутри установленного
+  компонента: `…/1C/1CE/components/1c-edt-<вер>-x86_64/1cedt (<вер>).app/Contents/Eclipse/plugins`
+  (shell-сборка находит его автоматически).
 
 ## Сборка
 
 **Вариант A — без Maven** (быстрее всего; локальный JDK + пул EDT, без сети):
 
 ```powershell
+# Windows
 powershell -ExecutionPolicy Bypass -File build-nomaven.ps1
 # или с переопределением путей:
 powershell -File build-nomaven.ps1 -Pool "D:\path\.p2\pool\plugins" -JdkHome "C:\path\to\jdk"
+```
+
+```bash
+# macOS / Linux — тот же результат. По умолчанию: --jdk-home из JAVA_HOME (или
+# `/usr/libexec/java_home -v 17` на macOS); --pool автоопределяется из пула установленного 1C:EDT.
+./build-nomaven.sh
+# или с переопределением путей:
+./build-nomaven.sh --pool "/path/to/Contents/Eclipse/plugins" --jdk-home "/path/to/jdk-17"
 ```
 
 Результат: `build/com.e1c.fresh.edtbridge_0.0.1.<timestamp>.jar`.
@@ -195,9 +222,13 @@ mvn -f pom.xml clean verify
 
 ## Установка и запуск
 
-1. Скопируйте собранный jar в папку `dropins/` вашего EDT
-   (напр. `…/installations/<EDT>/1cedt/dropins/`).
+1. Скопируйте собранный jar в папку `dropins/` вашего EDT — Windows: `…/installations/<EDT>/1cedt/dropins/`;
+   **macOS**: `…/1C/1CE/components/1c-edt-<вер>-x86_64/1cedt (<вер>).app/Contents/Eclipse/dropins/`
+   (создайте, если её нет).
 2. **Перезапустите EDT.** При старте плагин поднимет MCP-сервер на `http://127.0.0.1:8770/mcp`.
+
+Чтобы запустить EDT **headless** (без окна GUI), используйте `run-headless.ps1` (Windows) или
+`run-headless.sh --workspace <ws>` (macOS / Linux).
 
 Проверка через curl:
 

--- a/build-nomaven.sh
+++ b/build-nomaven.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# edt-bridge - no-Maven build (macOS / Linux).
+# Compiles + packages the OSGi bundle jar using a local JDK and the local 1C:EDT p2 bundle pool.
+# No network, no install. (For the standard build use Maven + Tycho: pom.xml.)
+# It does NOT install the bundle into EDT - copy the built jar to <EDT>/dropins/ and restart EDT.
+#
+# Defaults assume a typical install; override --pool / --jdk-home if yours differ.
+#
+#   ./build-nomaven.sh
+#   ./build-nomaven.sh --pool "/path/to/plugins" --jdk-home "/path/to/jdk-17"
+set -euo pipefail
+
+POOL=""
+JDK_HOME="${JAVA_HOME:-}"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --pool)     POOL="${2:?--pool needs a value}"; shift 2 ;;
+    --jdk-home) JDK_HOME="${2:?--jdk-home needs a value}"; shift 2 ;;
+    -h|--help)  grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+root="$(cd "$(dirname "$0")" && pwd)"
+bundle="$root/com.e1c.fresh.edtbridge"
+src="$bundle/src"
+out="$root/build"
+bin="$out/bin"
+
+# Resolve the JDK (need 17+). On macOS java_home can pick a matching JDK.
+if [ -z "$JDK_HOME" ] && [ -x /usr/libexec/java_home ]; then
+  JDK_HOME="$(/usr/libexec/java_home -v 17 2>/dev/null || true)"
+fi
+[ -n "$JDK_HOME" ] || { echo "Set --jdk-home <path> or the JAVA_HOME env var to a JDK 17+ home." >&2; exit 1; }
+JAVAC="$JDK_HOME/bin/javac"
+JAREXE="$JDK_HOME/bin/jar"
+[ -x "$JAVAC" ] || { echo "javac not found: $JAVAC (need a JDK 17+)" >&2; exit 1; }
+
+# Locate the EDT bundle pool - it must hold both the Eclipse base and the com._1c.g5.* bundles.
+# Candidates: each installed 1C:EDT component's self-contained pool (older RING components) plus
+# the shared ~/.p2/pool (newer installs provision there). Pick whichever holds the newest
+# com._1c.g5.v8.dt.core, so the default build targets the latest installed EDT.
+if [ -z "$POOL" ]; then
+  best_core=""
+  # read line-by-line: the .app directory name contains spaces.
+  while IFS= read -r cand; do
+    [ -d "$cand" ] || continue
+    core=""
+    for f in "$cand"/com._1c.g5.v8.dt.core_[0-9]*.jar; do
+      [ -e "$f" ] || continue
+      case "$f" in *.source_*.jar) continue ;; esac
+      core="$(basename "$f")"   # glob is sorted; last = newest within this pool
+    done
+    [ -n "$core" ] || continue
+    if [ -z "$best_core" ] || [[ "$core" > "$best_core" ]]; then best_core="$core"; POOL="$cand"; fi
+  done < <(
+    ls -d /Applications/1C/1CE/components/1c-edt-[0-9]*/*.app/Contents/Eclipse/plugins 2>/dev/null
+    echo "$HOME/.p2/pool/plugins")
+fi
+[ -n "$POOL" ] && [ -d "$POOL" ] || { echo "EDT bundle pool not found: '${POOL:-<empty>}' (pass --pool <.../Contents/Eclipse/plugins>)" >&2; exit 1; }
+
+# SWT fragment differs per OS (the host org.eclipse.swt is a stub; compile vs the platform fragment).
+case "$(uname -s)" in
+  Darwin) swt_glob='org.eclipse.swt.cocoa.macosx.*_*.jar' ;;
+  Linux)  swt_glob='org.eclipse.swt.gtk.linux.*_*.jar' ;;
+  *)      swt_glob='org.eclipse.swt.*_*.jar' ;;
+esac
+
+# Newest pool jar named "<id>_<digit>...": a digit right after "<id>_" excludes version-specific
+# siblings (e.g. com._1c.g5.v8.dt.platform_v8.3.27, which would shadow the real platform_11.x).
+resolve_jar() {
+  local id="$1" f b best=""
+  for f in "$POOL/${id}_"*.jar; do
+    [ -e "$f" ] || continue
+    b="$(basename "$f")"
+    case "$b" in "${id}_"[0-9]*) best="$f" ;; esac
+  done
+  printf '%s' "$best"
+}
+# Newest pool jar matching a glob, skipping ".source" siblings (used for the SWT fragment).
+resolve_glob() {
+  local pat="$1" f best=""
+  for f in "$POOL/"$pat; do
+    [ -e "$f" ] || continue
+    case "$f" in *.source_*.jar) continue ;; esac
+    best="$f"
+  done
+  printf '%s' "$best"
+}
+
+need=(
+  org.eclipse.osgi
+  org.eclipse.equinox.common
+  org.eclipse.core.resources
+  org.eclipse.core.runtime
+  org.eclipse.core.jobs
+  org.eclipse.ui.workbench
+  org.eclipse.ui
+  com.google.gson
+  org.eclipse.emf.ecore
+  org.eclipse.emf.common
+  org.eclipse.xtext
+  org.eclipse.xtext.util
+  com.google.inject
+  com.google.guava
+  com._1c.g5.wiring
+  com._1c.g5.v8.dt.core
+  com._1c.g5.v8.dt.metadata
+  com._1c.g5.v8.dt.mcore
+  com._1c.g5.v8.dt.bsl.model
+  com._1c.g5.v8.dt.bsl
+  com._1c.g5.v8.dt.form.model
+  com._1c.g5.v8.dt.form
+  com._1c.g5.v8.dt.form.layout
+  com._1c.g5.v8.dt.form.layout.model
+  com._1c.g5.v8.dt.form.presentation
+  com._1c.g5.v8.dt.platform
+  com._1c.g5.v8.dt.refactoring.core
+  com._1c.g5.v8.dt.md.refactoring
+  com._1c.g5.v8.bm.core
+  com._1c.g5.v8.bm.integration
+)
+
+echo "Pool: $POOL"
+echo "Classpath bundles:"
+cp=()
+for n in "${need[@]}"; do
+  j="$(resolve_jar "$n")"
+  if [ -n "$j" ]; then cp+=("$j"); echo "  + $(basename "$j")"; else echo "  ! MISSING: $n"; fi
+done
+swt="$(resolve_glob "$swt_glob")"
+if [ -n "$swt" ]; then cp+=("$swt"); echo "  + $(basename "$swt")"; else echo "  ! MISSING: SWT fragment ($swt_glob)"; fi
+cpStr="$(IFS=:; printf '%s' "${cp[*]}")"
+
+# Clean + compile.
+rm -rf "$out"
+mkdir -p "$bin"
+sources=()
+while IFS= read -r f; do sources+=("$f"); done < <(find "$src" -name '*.java')
+echo "Compiling ${#sources[@]} sources with --release 17 ..."
+"$JAVAC" --release 17 -encoding UTF-8 -cp "$cpStr" -d "$bin" "${sources[@]}"
+echo "OK: compiled."
+
+# Package the bundle jar (concrete version instead of .qualifier).
+cp "$bundle/plugin.xml" "$bin/"
+ts="$(date +%Y%m%d%H%M)"
+mf="$out/MANIFEST.MF"
+sed "s/0\.0\.1\.qualifier/0.0.1.$ts/" "$bundle/META-INF/MANIFEST.MF" > "$mf"
+jarPath="$out/com.e1c.fresh.edtbridge_0.0.1.$ts.jar"
+"$JAREXE" cfm "$jarPath" "$mf" -C "$bin" .
+echo "BUILT: $jarPath"
+echo "Install: copy to <EDT>/dropins/ and restart EDT, then curl http://127.0.0.1:8770/mcp"

--- a/run-headless.sh
+++ b/run-headless.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Run 1C:EDT headless (no GUI window) so the edt-bridge MCP server serves the live model.
+# Uses the EDT CLI's INTERACTIVE mode + a keepalive on stdin; the bundle's DS component
+# (OSGI-INF/edtbridge-mcp.xml) starts the server on activation, so no UI workbench is needed.
+#
+#   Start: ./run-headless.sh --workspace <ws> [--edt <.../Contents/Eclipse>]
+#   Stop : pkill -f 'edt.bridge.headless=1'; pkill -f 'sleep 2147483647'
+#
+# Why interactive + keepalive: bare "1cedtcli -data ws" idles without starting the runtime;
+# piping a command engages it, and the interactive shell keeps the OSGi framework (and the
+# DS-started server) alive. `sleep` keeps stdin open so the shell does not EOF-exit.
+#
+# -EdtDir is auto-detected (newest installed component) if omitted.
+set -euo pipefail
+
+WORKSPACE=""
+EDT=""
+PORT=8770
+WAIT=360
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workspace) WORKSPACE="${2:?--workspace needs a value}"; shift 2 ;;
+    --edt)       EDT="${2:?--edt needs a value}"; shift 2 ;;
+    --port)      PORT="${2:?--port needs a value}"; shift 2 ;;
+    --wait)      WAIT="${2:?--wait needs a value}"; shift 2 ;;
+    -h|--help)   grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+[ -n "$WORKSPACE" ] || { echo "--workspace <dir> is required." >&2; exit 2; }
+
+# Auto-detect the 1C:EDT installation (its Contents/Eclipse dir, where 1cedtcli lives). EDT lands
+# either as a RING component under /Applications, or a provisioned install under the start app's
+# installations dir. Keep only ones with an executable 1cedtcli; newest (lexical) wins.
+if [ -z "$EDT" ]; then
+  while IFS= read -r cand; do
+    [ -x "$cand/1cedtcli" ] && EDT="$cand"
+  done < <(
+    { ls -d /Applications/1C/1CE/components/1c-edt-[0-9]*/*.app/Contents/Eclipse 2>/dev/null
+      ls -d "$HOME/Library/Application Support/1C/1cedtstart/installations/"*/1cedt.app/Contents/Eclipse 2>/dev/null
+    } | sort)
+  [ -n "$EDT" ] || { echo "Could not auto-detect a provisioned 1C:EDT (need a 1cedtcli) - pass --edt <.../Contents/Eclipse>." >&2; exit 2; }
+fi
+CLI="$EDT/1cedtcli"
+DROPINS="$EDT/dropins"
+[ -x "$CLI" ] || { echo "1cedtcli not found/executable: $CLI" >&2; exit 2; }
+
+# 1) SAFETY: never touch a GUI 1C:EDT. If an EDT runtime is up that is NOT our headless one
+#    (no edt.bridge.headless marker), abort - the user may be working in it (and it holds the
+#    workspace lock). Only ever manage our own headless instance.
+if ps -Ao command= | grep -i 'org.eclipse.equinox.launcher' | grep -i '1cedt' | grep -iqv 'edt.bridge.headless=1'; then
+  echo "An EDT instance appears to be running (GUI or another session) - refusing to touch it." >&2
+  echo "Close it first, or run headless on a separate --workspace/--port." >&2
+  exit 2
+fi
+# Stop our prior headless CLI (marked JVM) and its keepalive, so repeated launches do not leave
+# orphans that keep the old jar locked.
+pkill -f 'edt.bridge.headless=1' 2>/dev/null || true
+pkill -f 'sleep 2147483647'      2>/dev/null || true
+sleep 3
+lock="$WORKSPACE/.metadata/.lock"
+[ -f "$lock" ] && rm -f "$lock" 2>/dev/null || true
+# Keep only the newest edt-bridge jar in dropins: two singletons of the same bundle make Equinox
+# resolve an arbitrary (often older) one. Purge the rest so the freshly built jar is the one loaded.
+mkdir -p "$DROPINS"
+ls -t "$DROPINS"/com.e1c.fresh.edtbridge_*.jar 2>/dev/null | tail -n +2 | while IFS= read -r f; do rm -f "$f"; done
+
+# 2) launch headless in the background. The marker -D lets us find/stop only our own instance;
+#    the write-tool auth token (and a non-default port) are propagated through -vmargs, which the
+#    native EDT launcher passes straight to the JVM (env is not inherited reliably).
+vmargs=(-Dedt.bridge.headless=1)
+[ -n "${EDT_BRIDGE_TOKEN:-}" ] && vmargs+=("-Dedt.bridge.token=${EDT_BRIDGE_TOKEN}")
+[ "$PORT" != 8770 ] && vmargs+=("-Dedt.bridge.port=${PORT}")
+nohup sh -c '(echo version; exec sleep 2147483647) | "$1" -data "$2" -nl en_US -vmargs '"${vmargs[*]}" \
+  _ "$CLI" "$WORKSPACE" >/dev/null 2>&1 &
+echo "Launched headless EDT (1cedtcli). Waiting up to ${WAIT}s for the server + model..."
+
+# 3) poll readiness: server up AND at least one project open (model loadable).
+deadline=$(( $(date +%s) + WAIT ))
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  s="$(curl -s --max-time 3 "http://127.0.0.1:${PORT}/status" 2>/dev/null || true)"
+  case "$s" in *'"openProjects":["'*) echo "READY: $s"; exit 0 ;; esac
+  sleep 5
+done
+alive=no; pgrep -f 'edt.bridge.headless=1' >/dev/null 2>&1 && alive=yes
+echo "NOT READY after ${WAIT}s (headless alive: $alive)"
+exit 1


### PR DESCRIPTION
## What

Adds first-class **macOS / Linux** support to the previously Windows-only build & run flow.

- **`build-nomaven.sh`** — Unix port of `build-nomaven.ps1`: `:` classpath separator, OS-specific SWT fragment (`cocoa.macosx` / `gtk.linux`), and EDT bundle-pool auto-detection that picks the pool with the newest `com._1c.g5.v8.dt.core` across the installed component pools (`/Applications/1C/1CE/components/...`) and the shared `~/.p2/pool`.
- **`run-headless.sh`** — Unix port of `run-headless.ps1`: `1cedtcli` discovery under both the `/Applications` components and the start-app `installations/` dir, a `sleep` keepalive on stdin, a `-Dedt.bridge.headless=1` marker so only our own instance is managed, a guard that refuses to touch a running GUI/other EDT session, and token/port pass-through via `-vmargs`.
- **`README.md`** — documents the macOS bundle-pool and `dropins` paths, plus the shell build invocation, in both the EN and RU sections.

No changes to the plugin sources or the Windows scripts.

## Verified

On **1C:EDT 2026.1 (macOS, Apple Silicon)**:
- `./build-nomaven.sh` auto-detects the 2026 pool and compiles clean (0 errors), producing the bundle jar.
- Dropped into `dropins/`, the plugin loads on EDT start and serves the live model over MCP: `/status` reports the open project, `tools/list` returns all 14 tools, and `edt_project_errors` returns real validation problems from the live model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)