### PR TITLE
Accept Russian class prefix in ownerFqn for attribute write tools

### DIFF
--- a/com.e1c.fresh.edtbridge/src/com/e1c/fresh/edtbridge/edt/EdtModelGateway.java
+++ b/com.e1c.fresh.edtbridge/src/com/e1c/fresh/edtbridge/edt/EdtModelGateway.java
@@ -1531,9 +1531,10 @@ public final class EdtModelGateway {
      * The {@code bsl_support_status = EDITABLE} gate before an apply is the caller's
      * responsibility — the EDT support API is not on the surface, so it stays a process gate for now.
      */
-    public AddAttrResult addAttribute(String projectName, String ownerFqn, String name, String typeSpec,
+    public AddAttrResult addAttribute(String projectName, String ownerFqnRaw, String name, String typeSpec,
             String synonymRu, String comment, boolean apply) {
         AddAttrResult r = new AddAttrResult();
+        final String ownerFqn = normalizeOwnerFqn(ownerFqnRaw);
         r.ownerFqn = ownerFqn;
         r.name = name;
         r.typeInput = typeSpec;
@@ -1712,9 +1713,10 @@ public final class EdtModelGateway {
      * Dry-run by default ({@code apply=false}) reports references + the plan. The caller must verify
      * {@code bsl_support_status = EDITABLE} before any apply.
      */
-    public RemoveAttrResult removeAttribute(String projectName, String ownerFqn, String name,
+    public RemoveAttrResult removeAttribute(String projectName, String ownerFqnRaw, String name,
             boolean apply, boolean force) {
         RemoveAttrResult r = new RemoveAttrResult();
+        final String ownerFqn = normalizeOwnerFqn(ownerFqnRaw);
         r.ownerFqn = ownerFqn;
         r.name = name;
         r.forced = force;
@@ -1884,9 +1886,10 @@ public final class EdtModelGateway {
      * a warning is returned. Dry-run by default ({@code apply=false}). Caller verifies
      * {@code bsl_support_status = EDITABLE} before apply.
      */
-    public ModifyAttrResult modifyAttribute(String projectName, String ownerFqn, String name,
+    public ModifyAttrResult modifyAttribute(String projectName, String ownerFqnRaw, String name,
             String newType, String newSynonymRu, String newComment, boolean apply) {
         ModifyAttrResult r = new ModifyAttrResult();
+        final String ownerFqn = normalizeOwnerFqn(ownerFqnRaw);
         r.ownerFqn = ownerFqn;
         r.name = name;
         IProject p = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
@@ -2358,6 +2361,25 @@ public final class EdtModelGateway {
             Map.entry("планобмена", "ExchangePlan"),
             Map.entry("константа", "Constant"),
             Map.entry("общиймодуль", "CommonModule"));
+
+    /**
+     * Normalize the class prefix of a top-object FQN from a Russian metadata kind
+     * (Справочник, Документ, …) to the English MdClass name (Catalog, Document, …)
+     * expected by {@code getTopObjectByFqn}. The object NAME (which may be Cyrillic)
+     * is left untouched. FQNs that already use an English prefix, or whose head is
+     * unknown, are returned unchanged.
+     */
+    private static String normalizeOwnerFqn(String fqn) {
+        if (fqn == null) {
+            return null;
+        }
+        int dot = fqn.indexOf('.');
+        if (dot <= 0) {
+            return fqn;
+        }
+        String en = CREATE_KIND_TO_MDCLASS.get(fqn.substring(0, dot).toLowerCase());
+        return en == null ? fqn : en + fqn.substring(dot);
+    }
 
     /** Result of {@link #createObject}. */
     public static final class CreateObjectResult {


### PR DESCRIPTION
## Problem

`edt_add_attribute`, `edt_remove_attribute` and `edt_modify_attribute` resolve the
owner object via `getTopObjectByFqn(ownerFqn)` with **no** RU→EN prefix normalization.
So only an English class prefix works:

- `Catalog.Контрагенты` ✅
- `Справочник.Контрагенты` ❌ → `owner object not found`

This is locale-independent (the technical FQN is always English-prefixed), so it
reproduces on every OS. The README example (`Справочник.Контрагенты`) actually fails.
Note the asymmetry: a Cyrillic object **name** works fine, only the Cyrillic **class
prefix** fails. The RU→EN maps that already exist are applied to the `type` field and
to `edt_create_object`'s `objectType`, but not to `ownerFqn`.

## Fix

Add `normalizeOwnerFqn()` that maps the leading metadata-kind segment from Russian to
the English MdClass name, **reusing the existing `CREATE_KIND_TO_MDCLASS` map** (no new
map). Applied at the entry of the three attribute write tools. The object name (which
may be Cyrillic) is untouched; English and unknown prefixes pass through unchanged, so
this is fully backward-compatible.

Covers all owner kinds in the map: `Справочник`/`Документ`/all register kinds/
`ПланВидовХарактеристик`/`ПланСчетов`/`ПланВидовРасчета`/`БизнесПроцесс`/`Задача`/`ПланОбмена`.

## Verification

Built against 1C:EDT 2026.1, tested live over MCP against a real project (dry-run):

| Owner | old jar (RU prefix) | new jar (RU prefix) |
|---|---|---|
| `Справочник.X` | `owner object not found` | resolves → `Catalog.X` |
| `Документ.X` | `owner object not found` | resolves → `Document.X` |
| `РегистрСведений.X` | `owner object not found` | resolves → `InformationRegister.X` |
| `РегистрНакопления.X` | `owner object not found` | resolves → `AccumulationRegister.X` |

All three write tools (`add`/`remove`/`modify`) confirmed to normalize the prefix.